### PR TITLE
Don’t use -f when it isn’t needed!

### DIFF
--- a/scripts/zypper.sh
+++ b/scripts/zypper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rm -rf /home/webhookd/logs/*
+rm -r /home/webhookd/logs/*
 
 printf "%s\n" "[$(curl -sL -u \
 "zyp_user:zyp_password_1" \

--- a/webhookd.env
+++ b/webhookd.env
@@ -68,6 +68,6 @@ export WHD_AUTH_HASH="296a5bd85a5a7b23625683937beacf17fc48e07ad62937bd647c69b55b
 
 export SHELL="/usr/sbin/nologin"
 
-rm -rf /home/webhookd/runner/*
+rm -r /home/webhookd/runner/*
 
-rm -rf /home/webhookd/logs/*
+rm -r /home/webhookd/logs/*


### PR DESCRIPTION
We shouldn’t use the force flag with rm if it can be avoided. rm -rf is usually only needed to remove Git directories. If we can do without here, we should.